### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/fb55/nth-check"
   },
+  "files": ["compile.js", "index.js", "parse.js"],
   "keywords": [
     "nth-child",
     "nth",


### PR DESCRIPTION
Prevents `.travis.yml` and `test.js` from being published to NPM.