### PR TITLE
fix: reject signless B in An+B formula (sign is mandatory per spec)

### DIFF
--- a/src/__fixtures__/rules.ts
+++ b/src/__fixtures__/rules.ts
@@ -47,4 +47,11 @@ export const invalid = [
     "b",
     "expr",
     "odd|even|x",
+
+    // Signless B after `An` is forbidden; the sign is mandatory.
+    "2n3",
+    "2n 3",
+    "n1",
+    "1n1",
+    "n 3",
 ];

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -39,6 +39,12 @@ export function parse(formula: string): [a: number, b: number] {
         skipWhitespace();
 
         if (index < formula.length) {
+            // The sign before `B` is mandatory: a signless integer is invalid.
+            const signChar = formula.charAt(index);
+            if (signChar !== "+" && signChar !== "-") {
+                throw new Error(`n-th rule couldn't be parsed ('${formula}')`);
+            }
+
             sign = readSign();
             skipWhitespace();
             number = readNumber();


### PR DESCRIPTION
## Bug

`parse()` accepts a signless integer as the `B` part after `An`, which the An+B grammar forbids: the sign before `B` is mandatory there. Browsers reject these as invalid selectors (`document.querySelector(":nth-child(2n3)")` throws).

| input | current result | expected |
|---|---|---|
| `parse("2n3")` | `[2, 3]` | throw |
| `parse("2n 3")` | `[2, 3]` | throw |
| `parse("n1")` | `[1, 1]` | throw |
| `parse("1n1")` | `[1, 1]` | throw |
| `parse("n 3")` | `[1, 3]` | throw |

## Spec

CSS Syntax Module Level 3 section 6.2, the `<an+b>` microsyntax: the `B` part after `An` is only `<signed-integer>` or `['+' | '-'] <signless-integer>`. In both productions an explicit `+`/`-` sign is required. A bare integer such as the `3` in `2n3` has no leading sign and is therefore invalid.

## Cause

In the post-`n` B-part branch, `readSign()` defaults to `+1` when no sign char is present, so a bare integer is silently consumed as `B`.

## Fix

One guard before `readSign()` in that branch: require the current char to be `+` or `-`, otherwise throw the existing parse error. No other behavior changes.

All existing `valid` fixtures still parse to identical `[a, b]`, and all existing `invalid` fixtures still throw. Added the five cases above to the `invalid` fixture set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Formula parser now enforces stricter validation rules requiring explicit signs for numeric offset values. Invalid patterns that previously passed validation are now correctly rejected with appropriate error messages.

* **Tests**
  * Expanded test suite with comprehensive coverage of invalid formula formats, including various signless patterns and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->